### PR TITLE
Add Spicetify plugin and Flask backend to extract stems

### DIFF
--- a/ExtractStems/extractStems.js
+++ b/ExtractStems/extractStems.js
@@ -1,0 +1,43 @@
+(function ExtractStems() {
+  const buttonId = "extract-stems-btn";
+
+  async function createButton() {
+    if (!Spicetify?.Player || document.getElementById(buttonId)) {
+      return;
+    }
+
+    const btn = document.createElement("button");
+    btn.id = buttonId;
+    btn.className = "control-button";
+    btn.textContent = "Extraire les stems";
+    btn.addEventListener("click", async () => {
+      const track = Spicetify.Player.data?.item;
+      if (!track) {
+        Spicetify.showNotification("Aucun morceau en cours");
+        return;
+      }
+      const title = track.name;
+      const artist = track.artists?.[0]?.name || "";
+      const query = encodeURIComponent(`${artist} - ${title}`);
+      try {
+        const res = await fetch(`http://localhost:5000/process?track=${query}`);
+        const data = await res.json();
+        if (res.ok && data.url) {
+          Spicetify.showNotification(`Stems prêts: ${data.url}`);
+        } else {
+          throw new Error(data.error || "Erreur inconnue");
+        }
+      } catch (e) {
+        Spicetify.showNotification(`Erreur: ${e.message}`);
+      }
+    });
+
+    const controls = document.querySelector(".main-nowPlayingBar-extraControls");
+    if (controls) {
+      controls.appendChild(btn);
+    }
+  }
+
+  createButton();
+  setInterval(createButton, 2000);
+})();

--- a/ExtractStems/manifest.json
+++ b/ExtractStems/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "ExtractStems",
+  "description": "Adds a button to extract stems via a local server",
+  "main": "extractStems.js",
+  "version": "1.0.0",
+  "author": "ChatGPT"
+}

--- a/server.py
+++ b/server.py
@@ -1,0 +1,77 @@
+import json
+import subprocess
+import tempfile
+import urllib.parse
+from pathlib import Path
+
+from flask import Flask, jsonify, request, send_from_directory, abort
+
+app = Flask(__name__)
+STEMS_DIR = Path("stems")
+STEMS_DIR.mkdir(exist_ok=True)
+
+
+def safe_path(name: str) -> Path:
+    """Return a safe path for storing stems of a track."""
+    safe = "".join(c for c in name if c.isalnum() or c in (" ", "-", "_"))
+    return STEMS_DIR / safe
+
+
+@app.route("/process")
+def process():
+    track = request.args.get("track")
+    if not track:
+        return jsonify(error="Missing track parameter"), 400
+
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            audio_path = tmpdir / "audio.mp3"
+            yt_cmd = [
+                "yt-dlp",
+                "-x",
+                "--audio-format",
+                "mp3",
+                "-o",
+                str(audio_path),
+                f"ytsearch1:{track}",
+            ]
+            subprocess.run(yt_cmd, check=True)
+
+            stem_out = safe_path(track)
+            stem_out.mkdir(parents=True, exist_ok=True)
+            demucs_cmd = [
+                "demucs",
+                "-n",
+                "htdemucs",
+                "-o",
+                str(stem_out),
+                str(audio_path),
+            ]
+            subprocess.run(demucs_cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        return jsonify(error=str(e)), 500
+
+    url = f"http://localhost:5000/download?stem_path={urllib.parse.quote(str(stem_out))}"
+    return jsonify(url=url)
+
+
+@app.route("/download")
+def download():
+    stem_path = request.args.get("stem_path")
+    if not stem_path:
+        files = [str(p.relative_to(STEMS_DIR)) for p in STEMS_DIR.rglob("*") if p.is_file()]
+        return jsonify(files=files)
+
+    path = Path(urllib.parse.unquote(stem_path))
+    if not path.exists():
+        abort(404)
+    if path.is_dir():
+        files = [f.name for f in path.iterdir() if f.is_file()]
+        links = [f'<a href="/download?stem_path={urllib.parse.quote(str(path / f))}">{f}</a>' for f in files]
+        return "<br>".join(links)
+    return send_from_directory(path.parent, path.name, as_attachment=True)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- Add ExtractStems Spicetify extension that injects a button for sending track info to a local server
- Implement Flask server that downloads tracks, separates stems with Demucs, and exposes download links

## Testing
- `node --check ExtractStems/extractStems.js`
- `python3 -m py_compile server.py`
- Start server with `python3 server.py` to ensure Flask boots

------
https://chatgpt.com/codex/tasks/task_e_688defdf49488324aa5531532b04edae