### PR TITLE
Ensure extract button loads without backend

### DIFF
--- a/ExtractStems/extractStems.js
+++ b/ExtractStems/extractStems.js
@@ -1,7 +1,8 @@
 (function ExtractStems() {
   const buttonId = "extract-stems-btn";
+  const serverUrl = "http://localhost:5000";
 
-  async function createButton() {
+  function createButton() {
     if (!Spicetify?.Player || document.getElementById(buttonId)) {
       return;
     }
@@ -10,31 +11,34 @@
     btn.id = buttonId;
     btn.className = "control-button";
     btn.textContent = "Extraire les stems";
-    btn.addEventListener("click", async () => {
-      const track = Spicetify.Player.data?.item;
-      if (!track) {
-        Spicetify.showNotification("Aucun morceau en cours");
-        return;
-      }
-      const title = track.name;
-      const artist = track.artists?.[0]?.name || "";
-      const query = encodeURIComponent(`${artist} - ${title}`);
-      try {
-        const res = await fetch(`http://localhost:5000/process?track=${query}`);
-        const data = await res.json();
-        if (res.ok && data.url) {
-          Spicetify.showNotification(`Stems prêts: ${data.url}`);
-        } else {
-          throw new Error(data.error || "Erreur inconnue");
-        }
-      } catch (e) {
-        Spicetify.showNotification(`Erreur: ${e.message}`);
-      }
-    });
+    btn.addEventListener("click", handleClick);
 
     const controls = document.querySelector(".main-nowPlayingBar-extraControls");
     if (controls) {
       controls.appendChild(btn);
+    }
+  }
+
+  async function handleClick() {
+    const track = Spicetify.Player.data?.item;
+    if (!track) {
+      Spicetify.showNotification("Aucun morceau en cours");
+      return;
+    }
+    const title = track.name;
+    const artist = track.artists?.[0]?.name || "";
+    const query = encodeURIComponent(`${artist} - ${title}`);
+    try {
+      const res = await fetch(`${serverUrl}/process?track=${query}`);
+      const data = await res.json();
+      if (res.ok && data.url) {
+        Spicetify.showNotification(`Stems prêts: ${data.url}`);
+      } else {
+        throw new Error(data.error || "Erreur inconnue");
+      }
+    } catch (e) {
+      console.error(e);
+      Spicetify.showNotification("Serveur injoignable");
     }
   }
 


### PR DESCRIPTION
## Summary
- Always render "Extraire les stems" button without pinging backend
- Gracefully handle unreachable server and log errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688df5d225c08324a0358e6d596fd694